### PR TITLE
Added tests for fsz/fs and updated registry.

### DIFF
--- a/test/resolve.js
+++ b/test/resolve.js
@@ -28,7 +28,9 @@ registry.add({
 	'fl': 'float:left|right|none',
 	'fef': 'font-effect:none|engrave|emboss|outline',
 	'trf': 'transform:${1}|skewX(${1:angle})|skewY(${1:angle})|scale(${1:x}, ${2:y})|scaleX(${1:x})|scaleY(${1:y})|scaleZ(${1:z})|scale3d(${1:x}, ${2:y}, ${3:z})|rotate(${1:angle})|rotateX(${1:angle})|rotateY(${1:angle})|rotateZ(${1:angle})|translate(${1:x}, ${2:y})|translateX(${1:x})|translateY(${1:y})|translateZ(${1:z})|translate3d(${1:tx}, ${2:ty}, ${3:tz})',
-	'@kf': '@keyframes ${1:identifier} {\n\t${2}\n}'
+	'@kf': '@keyframes ${1:identifier} {\n\t${2}\n}',
+	'fsz': 'font-size',
+	"fs" : 'font-style:italic|normal|oblique'
 });
 
 function expand(abbr, options) {
@@ -58,6 +60,13 @@ function stringify(tree) {
 }
 
 describe('CSS resolver', () => {
+	it('font-style vs font-size', () => {
+		assert.equal(expand('fsz12'), 'font-size: 12px;');
+		assert.equal(expand('fz12'), 'font-size: 12px;');
+		assert.equal(expand('fsi'), 'font-style: italic;');
+		assert.equal(expand('fso'), 'font-style: oblique;');
+	});
+
 	it('keywords', () => {
 		assert.equal(expand('bd1-s'), 'border: 1px solid;');
 		assert.equal(expand('dib'), 'display: inline-block;');


### PR DESCRIPTION
This PR fixes https://github.com/Microsoft/vscode/issues/59951.

It updates `"fz": "font-size"` to `"fsz": "font-size"` .

This is to fix `fsz` being associated with `font-style`.

I ran the test and it seems like `font-style` is unaffected.

Thanks for considering this request.